### PR TITLE
Update Homebrew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### Using Homebrew
 
 ```
-brew cask install telegram
+brew install telegram --cask
 ```
 
 ### Using `mas-cli`


### PR DESCRIPTION
a quick fix on the documentation so we don't get someone that is new to `brew` wondering

```bash
❯ brew cask install telegram
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

with the right command
```bash
❯ brew install telegram --cask
==> Downloading https://formulae.brew.sh/api/cask.jws.json
...
```